### PR TITLE
Replaced runCatching {} with resultOf{}

### DIFF
--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/GetStatus.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/GetStatus.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.statium
 
 import eu.europa.ec.eudi.statium.misc.Decompress
+import eu.europa.ec.eudi.statium.misc.resultOf
 import kotlinx.datetime.Instant
 
 /**
@@ -58,7 +59,7 @@ public fun interface GetStatus {
             getStatusListToken: GetStatusListToken,
             decompress: Decompress = platformDecompress(),
         ): GetStatus = GetStatus { at ->
-            runCatching {
+            resultOf {
                 val statusListTokenClaims = getStatusListToken(uri, at).getOrThrow()
                 val statusList = statusListTokenClaims.statusList
                 val readStatus = ReadStatus.fromStatusList(statusList, decompress).getOrThrow()

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/GetStatusListToken.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/GetStatusListToken.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.statium
 
 import eu.europa.ec.eudi.statium.http.GetStatusListTokenKtorOps
 import eu.europa.ec.eudi.statium.jose.jwtHeaderAndPayload
+import eu.europa.ec.eudi.statium.misc.resultOf
 import io.ktor.client.*
 import io.ktor.utils.io.core.*
 import kotlinx.datetime.Clock
@@ -55,7 +56,7 @@ internal class GetStatusListTokenUsingJwt(
     }
 
     override suspend fun invoke(uri: String, at: Instant?): Result<StatusListTokenClaims> =
-        runCatching {
+        resultOf {
             val unverifiedJwt = fetchToken(uri, at)
             val validationTime = at ?: clock.now()
             verifySignature(unverifiedJwt, validationTime)

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Platform.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Platform.kt
@@ -32,3 +32,5 @@ internal expect fun platformDecompress(context: CoroutineContext): Decompress
  * Creates a platform-specific Decompress implementation with the default IO context
  */
 internal fun platformDecompress(): Decompress = platformDecompress(platformIoContext())
+
+public expect fun platformNonFatal(throwable: Throwable): Boolean

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/ReadStatus.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/ReadStatus.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.statium
 
 import eu.europa.ec.eudi.statium.BitsPerStatus.*
 import eu.europa.ec.eudi.statium.misc.Decompress
+import eu.europa.ec.eudi.statium.misc.resultOf
 
 /**
  * Reads a status at a specific [index][StatusIndex]
@@ -33,7 +34,7 @@ public fun interface ReadStatus {
          */
         public fun fromByteArray(bitsPerStatus: BitsPerStatus, statusList: ByteArray): ReadStatus =
             ReadStatus { index ->
-                runCatching {
+                resultOf {
                     with(bitsPerStatus) {
                         val (bytePosition, bitPosition) = byteAndBitPosition(index)
                         val byte = statusList[bytePosition]
@@ -49,7 +50,7 @@ public fun interface ReadStatus {
             statusList: StatusList,
             decompress: Decompress = platformDecompress(),
         ): Result<ReadStatus> =
-            runCatching {
+            resultOf {
                 val decompressedList = decompress(statusList.compressedList)
                 fromByteArray(statusList.bytesPerStatus, decompressedList)
             }

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/Types.kt
@@ -20,6 +20,7 @@ import eu.europa.ec.eudi.statium.misc.Base64UrlNoPadding
 import eu.europa.ec.eudi.statium.misc.BitsPerStatusSerializer
 import eu.europa.ec.eudi.statium.misc.EpocSecondsSerializer
 import eu.europa.ec.eudi.statium.misc.StatiumJsonSerializersModule
+import eu.europa.ec.eudi.statium.misc.resultOf
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Required
@@ -135,7 +136,7 @@ public data class StatusList(
             base64UrlEncodedList: String,
             aggregationUri: String? = null,
         ): Result<StatusList> =
-            runCatching {
+            resultOf {
                 val compressedList = Base64UrlNoPadding.decode(base64UrlEncodedList)
                 StatusList(bytesPerStatus, compressedList, aggregationUri)
             }

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/http/GetStatusListTokenKtorOps.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/http/GetStatusListTokenKtorOps.kt
@@ -17,6 +17,7 @@ package eu.europa.ec.eudi.statium.http
 
 import eu.europa.ec.eudi.statium.StatusListTokenFormat
 import eu.europa.ec.eudi.statium.TokenStatusListSpec
+import eu.europa.ec.eudi.statium.misc.resultOf
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -34,7 +35,7 @@ public interface GetStatusListTokenKtorOps {
         format: StatusListTokenFormat,
         at: Instant?,
     ): Result<String> =
-        runCatching {
+        resultOf {
             val httpResponse = get(uri) {
                 accept(format.contentType())
                 at?.let { parameter(TokenStatusListSpec.TIME, it.epochSeconds) }

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/jose/Jwt.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/jose/Jwt.kt
@@ -17,12 +17,13 @@ package eu.europa.ec.eudi.statium.jose
 
 import eu.europa.ec.eudi.statium.misc.Base64UrlNoPadding
 import eu.europa.ec.eudi.statium.misc.StatiumJson
+import eu.europa.ec.eudi.statium.misc.resultOf
 import kotlinx.io.Buffer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.io.decodeFromSource
 
 internal inline fun <reified H, reified P> jwtHeaderAndPayload(jwt: String): Result<Pair<H, P>> =
-    runCatching {
+    resultOf {
         val (headerPart, payloadPart, _) = parts(jwt)
         with(StatiumJson) {
             val header = decodeBase64<H>(headerPart)

--- a/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/ResultOf.kt
+++ b/lib/src/commonMain/kotlin/eu/europa/ec/eudi/statium/misc/ResultOf.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.statium.misc
+
+import eu.europa.ec.eudi.statium.platformNonFatal
+
+public inline fun <T, R> T.resultOf(block: () -> R): Result<R> =
+    try {
+        Result.success(block())
+    } catch (e: Throwable) {
+        if (platformNonFatal(e)) Result.failure(e) else throw e
+    }
+
+public inline fun <R> resultOf(block: () -> R): Result<R> =
+    try {
+        Result.success(block())
+    } catch (e: Throwable) {
+        if (platformNonFatal(e)) Result.failure(e) else throw e
+    }

--- a/lib/src/iosMain/kotlin/eu/europa/ec/eudi/statium/Platform.iOS.kt
+++ b/lib/src/iosMain/kotlin/eu/europa/ec/eudi/statium/Platform.iOS.kt
@@ -16,6 +16,7 @@
 package eu.europa.ec.eudi.statium
 import eu.europa.ec.eudi.statium.misc.Decompress
 import eu.europa.ec.eudi.statium.misc.IOSDecompress
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
@@ -25,3 +26,9 @@ internal actual fun platformDecompress(context: CoroutineContext): Decompress = 
  * Returns a platform-specific CoroutineContext suitable for IO operations
  */
 internal actual fun platformIoContext(): CoroutineContext = Dispatchers.Default
+
+public actual fun platformNonFatal(throwable: Throwable): Boolean =
+    when (throwable) {
+        is CancellationException -> false
+        else -> true
+    }

--- a/lib/src/jvmAndAndroidMain/kotlin/eu/europa/ec/eudi/statium/Platform.jvmAndAndroid.kt
+++ b/lib/src/jvmAndAndroidMain/kotlin/eu/europa/ec/eudi/statium/Platform.jvmAndAndroid.kt
@@ -17,9 +17,19 @@ package eu.europa.ec.eudi.statium
 
 import eu.europa.ec.eudi.statium.misc.Decompress
 import eu.europa.ec.eudi.statium.misc.JvmAndroidDecompress
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
 internal actual fun platformIoContext(): CoroutineContext = Dispatchers.IO
 
 internal actual fun platformDecompress(context: CoroutineContext): Decompress = JvmAndroidDecompress(context)
+
+//
+// From https://github.com/arrow-kt/arrow/blob/main/arrow-libs/core/arrow-core/src/androidAndJvmMain/kotlin/arrow/core/NonFatal.kt
+//
+public actual fun platformNonFatal(throwable: Throwable): Boolean =
+    when (throwable) {
+        is VirtualMachineError, is ThreadDeath, is InterruptedException, is LinkageError, is CancellationException -> false
+        else -> true
+    }


### PR DESCRIPTION
The PR replaces `runCatching{ }`  with `resultOf { }` which doesn't trap Cancellation or other fatal Exceptions

In ios platform the only exception that should not be caught is CancellationException
In jvm there are more fatal exceptions