### PR TITLE
Updated ci.yml workflow to include ios targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-gradle:
-    name: Build
+    name: Build (JVM & Android)
     runs-on: ubuntu-latest
     outputs:
       code-version: ${{ steps.extract.outputs.CODE_VERSION }}
@@ -31,9 +31,34 @@ jobs:
         name: Extract code version from gradle.properties
         run: echo "CODE_VERSION=$(awk -F= '$1~/version/{print $2}' gradle.properties)" >> $GITHUB_OUTPUT
 
+  build-ios:
+    name: Build (iOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          architecture: x64
+      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Build iOS targets
+        env:
+          CI: true
+        run: |
+          ./gradlew iosX64Test iosArm64Test iosSimulatorArm64Test
+          ./gradlew assembleXCFramework
+      - name: Upload XCFramework
+        uses: actions/upload-artifact@v4
+        with:
+          name: lib-xcframework
+          path: lib/build/XCFrameworks/release/
+          retention-days: 7
+
   publish-to-sonatype-snapshot:
     name: Publish to sonatype.org (SNAPSHOT)
-    needs: [ build-gradle ]
+    needs: [ build-gradle, build-ios ]
     if: github.event_name != 'pull_request' && endsWith(needs.build-gradle.outputs.code-version, '-SNAPSHOT') && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')) &&  github.repository_owner == 'eu-digital-identity-wallet'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           CI: true
         run: |
-          ./gradlew iosX64Test iosArm64Test iosSimulatorArm64Test
+          ./gradlew iosX64Test iosSimulatorArm64Test
           ./gradlew assembleXCFramework
       - name: Upload XCFramework
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
1. **Rename the first job** to "Build (JVM & Android)" to clarify its scope
2. **Add a new job `build-ios`** that:
   - Runs on `macos-latest` (required for iOS builds)
   - Builds and tests all iOS targets (iosX64, iosArm64, iosSimulatorArm64)
   - Generates the XCFramework using `assembleXCFramework` task
   - Uploads the XCFramework as an artifact for easy access
3. **Update the publish job** to depend on both build jobs